### PR TITLE
Extension of Level-8: Intelligent Date Inference

### DIFF
--- a/src/main/java/reverie/command/ScheduleCommand.java
+++ b/src/main/java/reverie/command/ScheduleCommand.java
@@ -47,12 +47,17 @@ public class ScheduleCommand extends Command {
         for (int i = 0; i < allTasks.size(); i++) {
             Task task = allTasks.get(i);
             if (task instanceof Deadline deadline) {
-                if (deadline.getByDate() != null && deadline.getByDate().equals(targetDate)) {
+                LocalDateTime byDateTime = deadline.getByDateTime();
+                if (byDateTime != null && byDateTime.toLocalDate().equals(targetDate)) {
                     matchingIndices.add(i);
                 }
             } else if (task instanceof Event event) {
-                if (event.getFromDate() != null && event.getToDate() != null) {
-                    if (!targetDate.isBefore(event.getFromDate()) && !targetDate.isAfter(event.getToDate())) {
+                LocalDateTime fromDateTime = event.getFromDateTime();
+                LocalDateTime toDateTime = event.getToDateTime();
+                if (fromDateTime != null && toDateTime != null) {
+                    LocalDate fromDate = fromDateTime.toLocalDate();
+                    LocalDate toDate = toDateTime.toLocalDate();
+                    if (!targetDate.isBefore(fromDate) && !targetDate.isAfter(toDate)) {
                         matchingIndices.add(i);
                     }
                 }

--- a/src/main/java/reverie/command/ScheduleCommand.java
+++ b/src/main/java/reverie/command/ScheduleCommand.java
@@ -8,6 +8,7 @@ import reverie.task.Task;
 import reverie.ui.TaskList;
 import reverie.ui.Ui;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;

--- a/src/main/java/reverie/parser/DateTimeParser.java
+++ b/src/main/java/reverie/parser/DateTimeParser.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,29 +26,29 @@ public class DateTimeParser {
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HHmm"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HH:mm"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HHmm"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HHmm"));
-        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HHmm").withLocale(Locale.ENGLISH));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HH:mm").withLocale(Locale.ENGLISH));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HHmm").withLocale(Locale.ENGLISH));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm").withLocale(Locale.ENGLISH));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HHmm").withLocale(Locale.ENGLISH));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm").withLocale(Locale.ENGLISH));
 
         // Date-only formats
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
-        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy"));
-        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy"));
-        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy").withLocale(Locale.ENGLISH));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy").withLocale(Locale.ENGLISH));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd").withLocale(Locale.ENGLISH));
 
         // Time-only formats
         TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("HHmm"));
         TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("HH:mm"));
-        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mm a"));
-        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mma"));
-        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mm a"));
-        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mma"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mm a").withLocale(java.util.Locale.ENGLISH));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mma").withLocale(java.util.Locale.ENGLISH));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mm a").withLocale(java.util.Locale.ENGLISH));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mma").withLocale(java.util.Locale.ENGLISH));
     }
 
     /**
@@ -83,10 +84,13 @@ public class DateTimeParser {
 
         String trimmed = input.trim();
 
+        // Normalize AM/PM to uppercase for easier parsing
+        String normalized = trimmed.replaceAll("(?i)am", "AM").replaceAll("(?i)pm", "PM");
+
         // Try full date-time formats first
         for (DateTimeFormatter formatter : DATE_TIME_FORMATTERS) {
             try {
-                return new ParseResult(LocalDateTime.parse(trimmed, formatter), true);
+                return new ParseResult(LocalDateTime.parse(normalized, formatter), true);
             } catch (DateTimeParseException ignored) {
             }
         }
@@ -94,7 +98,7 @@ public class DateTimeParser {
         // Try date-only formats (set time to 00:00)
         for (DateTimeFormatter formatter : DATE_FORMATTERS) {
             try {
-                LocalDate date = LocalDate.parse(trimmed, formatter);
+                LocalDate date = LocalDate.parse(normalized, formatter);
                 return new ParseResult(date.atStartOfDay(), false);
             } catch (DateTimeParseException ignored) {
             }
@@ -103,7 +107,7 @@ public class DateTimeParser {
         // Try time-only formats (set date to today)
         for (DateTimeFormatter formatter : TIME_FORMATTERS) {
             try {
-                LocalTime time = LocalTime.parse(trimmed, formatter);
+                LocalTime time = LocalTime.parse(normalized, formatter);
                 return new ParseResult(LocalDateTime.of(LocalDate.now(), time), true);
             } catch (DateTimeParseException ignored) {
             }

--- a/src/main/java/reverie/parser/DateTimeParser.java
+++ b/src/main/java/reverie/parser/DateTimeParser.java
@@ -25,6 +25,8 @@ public class DateTimeParser {
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HHmm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HHmm"));

--- a/src/main/java/reverie/parser/DateTimeParser.java
+++ b/src/main/java/reverie/parser/DateTimeParser.java
@@ -1,4 +1,4 @@
-package reverie.task;
+package reverie.parser;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/reverie/parser/Parser.java
+++ b/src/main/java/reverie/parser/Parser.java
@@ -48,8 +48,8 @@ public class Parser {
         if (input.length() <= "deadline ".length()) {
             throw new ReverieException("""
                     The description of a deadline cannot be empty!
-                    Format: deadline <description> /by <time>
-                    Date format: yyyy-MM-dd (e.g., 2019-12-02)""");
+                    Format: deadline <description> /by <date-time>
+                    Date-time examples: 2019-12-02 1800, 2019-12-02, 1800, Dec 02 2019, meeting tomorrow, etc.""");
         }
 
         String content = input.replaceFirst("(?i)^deadline\\s+", "").trim();

--- a/src/main/java/reverie/parser/Parser.java
+++ b/src/main/java/reverie/parser/Parser.java
@@ -58,8 +58,8 @@ public class Parser {
         if (parts.length < 2) {
             throw new ReverieException("""
                     Invalid deadline format!
-                    Format: deadline <description> /by <time>
-                    Date format: yyyy-MM-dd (e.g., 2019-12-02)""");
+                    Format: deadline <description> /by <date-time>
+                    Date-time examples: 2019-12-02 1800, 2019-12-02, 1800, Dec 02 2019, meeting tomorrow, etc.""");
         }
 
         String description = parts[0].trim();

--- a/src/main/java/reverie/parser/Parser.java
+++ b/src/main/java/reverie/parser/Parser.java
@@ -110,7 +110,7 @@ public class Parser {
             throw new ReverieException("""
                     Invalid event format!
                     Format: event <description> /from <start> /to <end>
-                    Date format: yyyy-MM-dd (e.g., 2019-12-02)""");
+                    Date-time examples: 2019-12-02 1800, 2019-12-02, 1800, Dec 02 2019, etc.""");
         }
         return parts;
     }

--- a/src/main/java/reverie/parser/Parser.java
+++ b/src/main/java/reverie/parser/Parser.java
@@ -100,7 +100,7 @@ public class Parser {
             throw new ReverieException("""
                     The description of an event cannot be empty!
                     Format: event <description> /from <start> /to <end>
-                    Date format: yyyy-MM-dd (e.g., 2019-12-02)""");
+                    Date-time examples: 2019-12-02 1800, 2019-12-02, 1800, Dec 02 2019, etc.""");
         }
 
         String content = input.replaceFirst("(?i)^event\\s+", "").trim();

--- a/src/main/java/reverie/storage/Storage.java
+++ b/src/main/java/reverie/storage/Storage.java
@@ -141,10 +141,16 @@ public class Storage {
     }
 
     private Task createDeadline(String description, String[] parts) throws ReverieException {
-        if (parts.length != 4) {
+        if (parts.length == 4) {
+            // Old format without hasTime flag - default to false (date only)
+            return new Deadline(description, parts[3].trim(), false);
+        } else if (parts.length == 5) {
+            // New format with hasTime flag
+            boolean hasTime = parts[4].trim().equals("1");
+            return new Deadline(description, parts[3].trim(), hasTime);
+        } else {
             throw new ReverieException("Invalid Deadline format");
         }
-        return new Deadline(description, parts[3].trim());
     }
 
     private Task createEvent(String description, String[] parts) throws ReverieException {

--- a/src/main/java/reverie/storage/Storage.java
+++ b/src/main/java/reverie/storage/Storage.java
@@ -95,7 +95,9 @@ public class Storage {
     }
 
     private String formatEvent(Event event, String isDone) {
-        return "E | " + isDone + " | " + event.getDescription() + " | " + event.getFromString() + " | " + event.getToString();
+        return "E | " + isDone + " | " + event.getDescription() + " | " +
+                event.getFromString() + " | " + event.getToString() + " | " +
+                (event.hasTime() ? "1" : "0");
     }
 
     private Task parseTaskFromFile(String line) throws ReverieException {

--- a/src/main/java/reverie/storage/Storage.java
+++ b/src/main/java/reverie/storage/Storage.java
@@ -90,7 +90,8 @@ public class Storage {
     }
 
     private String formatDeadline(Deadline deadline, String isDone) {
-        return "D | " + isDone + " | " + deadline.getDescription() + " | " + deadline.getByString();
+        return "D | " + isDone + " | " + deadline.getDescription() + " | " +
+                deadline.getByString() + " | " + (deadline.hasTime() ? "1" : "0");
     }
 
     private String formatEvent(Event event, String isDone) {

--- a/src/main/java/reverie/storage/Storage.java
+++ b/src/main/java/reverie/storage/Storage.java
@@ -154,10 +154,16 @@ public class Storage {
     }
 
     private Task createEvent(String description, String[] parts) throws ReverieException {
-        if (parts.length != 5) {
+        if (parts.length == 5) {
+            // Old format without hasTime flag - default to false (date only)
+            return new Event(description, parts[3].trim(), parts[4].trim(), false);
+        } else if (parts.length == 6) {
+            // New format with hasTime flag
+            boolean hasTime = parts[5].trim().equals("1");
+            return new Event(description, parts[3].trim(), parts[4].trim(), hasTime);
+        } else {
             throw new ReverieException("Invalid Event format");
         }
-        return new Event(description, parts[3].trim(), parts[4].trim());
     }
     /* private static final String FILE_PATH = "./data/reverie.txt";
     private static final String DATA_DIRECTORY = "./data";

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -56,5 +56,13 @@ public class DateTimeParser {
             this.dateTime = dateTime;
             this.hasTime = hasTime;
         }
+
+        public LocalDateTime getDateTime() {
+            return dateTime;
+        }
+
+        public boolean hasTime() {
+            return hasTime;
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -69,6 +69,11 @@ public class DateTimeParser {
         }
     }
 
+    /**
+     * Parses a date-time string flexibly.
+     * Returns LocalDateTime if parsing succeeds, null if input is plain text.
+     * Returns a ParseResult indicating whether time was included in the input.
+     */
     public static ParseResult parseDateTime(String input) {
         if (input == null || input.trim().isEmpty()) {
             return new ParseResult(null, false);

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -1,5 +1,7 @@
 package reverie.task;
 
 public class DateTimeParser {
-    
+    private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = new ArrayList<>();
+    private static final List<DateTimeFormatter> DATE_FORMATTERS = new ArrayList<>();
+    private static final List<DateTimeFormatter> TIME_FORMATTERS = new ArrayList<>();
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -51,5 +51,10 @@ public class DateTimeParser {
     public static class ParseResult {
         private final LocalDateTime dateTime;
         private final boolean hasTime;
+
+        public ParseResult(LocalDateTime dateTime, boolean hasTime) {
+            this.dateTime = dateTime;
+            this.hasTime = hasTime;
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -29,5 +29,14 @@ public class DateTimeParser {
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HHmm"));
         DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm"));
+
+        // Date-only formats
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy"));
+        DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd"));
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -38,5 +38,13 @@ public class DateTimeParser {
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy"));
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy"));
         DATE_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy MMM dd"));
+
+        // Time-only formats
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("HHmm"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("HH:mm"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mm a"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("hh:mma"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mm a"));
+        TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mma"));
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -48,6 +48,9 @@ public class DateTimeParser {
         TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mma"));
     }
 
+    /**
+     * Result of parsing that includes both the LocalDateTime and whether time was present
+     */
     public static class ParseResult {
         private final LocalDateTime dateTime;
         private final boolean hasTime;

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -12,4 +12,22 @@ public class DateTimeParser {
     private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = new ArrayList<>();
     private static final List<DateTimeFormatter> DATE_FORMATTERS = new ArrayList<>();
     private static final List<DateTimeFormatter> TIME_FORMATTERS = new ArrayList<>();
+
+    static {
+        // Date-time formats (with both date and time)
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy/MM/dd HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HHmm"));
+        DATE_TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm"));
+    }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -101,5 +101,8 @@ public class DateTimeParser {
             } catch (DateTimeParseException ignored) {
             }
         }
+
+        // If all parsing fails, return null (treat as plain text)
+        return new ParseResult(null, false);
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -83,5 +83,14 @@ public class DateTimeParser {
             } catch (DateTimeParseException ignored) {
             }
         }
+
+        // Try date-only formats (set time to 00:00)
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                LocalDate date = LocalDate.parse(trimmed, formatter);
+                return new ParseResult(date.atStartOfDay(), false);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -47,4 +47,8 @@ public class DateTimeParser {
         TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mm a"));
         TIME_FORMATTERS.add(DateTimeFormatter.ofPattern("h:mma"));
     }
+
+    public static class ParseResult {
+        
+    }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -1,0 +1,5 @@
+package reverie.task;
+
+public class DateTimeParser {
+    
+}

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -49,6 +49,7 @@ public class DateTimeParser {
     }
 
     public static class ParseResult {
-        
+        private final LocalDateTime dateTime;
+        private final boolean hasTime;
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -68,4 +68,8 @@ public class DateTimeParser {
             return hasTime;
         }
     }
+
+    public static ParseResult parseDateTime(String input) {
+        
+    }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -73,5 +73,15 @@ public class DateTimeParser {
         if (input == null || input.trim().isEmpty()) {
             return new ParseResult(null, false);
         }
+
+        String trimmed = input.trim();
+
+        // Try full date-time formats first
+        for (DateTimeFormatter formatter : DATE_TIME_FORMATTERS) {
+            try {
+                return new ParseResult(LocalDateTime.parse(trimmed, formatter), true);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -92,5 +92,14 @@ public class DateTimeParser {
             } catch (DateTimeParseException ignored) {
             }
         }
+
+        // Try time-only formats (set date to today)
+        for (DateTimeFormatter formatter : TIME_FORMATTERS) {
+            try {
+                LocalTime time = LocalTime.parse(trimmed, formatter);
+                return new ParseResult(LocalDateTime.of(LocalDate.now(), time), true);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -70,6 +70,8 @@ public class DateTimeParser {
     }
 
     public static ParseResult parseDateTime(String input) {
-        
+        if (input == null || input.trim().isEmpty()) {
+            return new ParseResult(null, false);
+        }
     }
 }

--- a/src/main/java/reverie/task/DateTimeParser.java
+++ b/src/main/java/reverie/task/DateTimeParser.java
@@ -1,5 +1,13 @@
 package reverie.task;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
 public class DateTimeParser {
     private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = new ArrayList<>();
     private static final List<DateTimeFormatter> DATE_FORMATTERS = new ArrayList<>();

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -35,19 +35,11 @@ public class Deadline extends Task {
     public boolean hasTime() {
         return hasTime;
     }
-    
+
     public String getByString() {
         return by;
     }
-
-    private LocalDate parseDate(String dateString) throws ReverieException {
-        try {
-            return LocalDate.parse(dateString, INPUT_FORMAT);
-        } catch (DateTimeParseException e) {
-            throw new ReverieException("Invalid date format. Please use yyyy-MM-dd (e.g., 2019-12-02)");
-        }
-    }
-
+    
     @Override
     public String getFullStatus() {
         String dateString = byDate != null ? byDate.format(OUTPUT_FORMAT) : by;

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -1,9 +1,8 @@
 package reverie.task;
 
 import reverie.exception.ReverieException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 public class Deadline extends Task {

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -39,10 +39,15 @@ public class Deadline extends Task {
     public String getByString() {
         return by;
     }
-    
+
     @Override
     public String getFullStatus() {
-        String dateString = byDate != null ? byDate.format(OUTPUT_FORMAT) : by;
+        String dateString;
+        if (byDateTime != null) {
+            dateString = hasTime ? byDateTime.format(OUTPUT_FORMAT_WITH_TIME) : byDateTime.format(OUTPUT_FORMAT_DATE_ONLY);
+        } else {
+            dateString = by;
+        }
         return "[D]" + super.getFullStatus() + " (by: " + dateString + ")";
     }
 

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -51,7 +51,7 @@ public class Deadline extends Task {
         return "[D]" + super.getFullStatus() + " (by: " + dateString + ")";
     }
 
-    public LocalDate getByDate() {
-        return byDate;
+    public LocalDateTime getByDateTime() {
+        return byDateTime;
     }
 }

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -7,10 +7,12 @@ import java.util.Locale;
 
 public class Deadline extends Task {
     protected String by;
-    protected LocalDate byDate;
-    private static final DateTimeFormatter INPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter OUTPUT_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
-
+    protected LocalDateTime byDateTime;
+    protected boolean hasTime;
+    private static final DateTimeFormatter OUTPUT_FORMAT_WITH_TIME =
+            DateTimeFormatter.ofPattern("HH:mm MMM dd yyyy", Locale.ENGLISH);
+    private static final DateTimeFormatter OUTPUT_FORMAT_DATE_ONLY =
+            DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
     public Deadline(String description, String by) throws ReverieException {
         super(description);
         this.by = by;

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -32,6 +32,10 @@ public class Deadline extends Task {
         this.hasTime = hasTime;
     }
 
+    public boolean hasTime() {
+        return hasTime;
+    }
+    
     public String getByString() {
         return by;
     }

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -1,5 +1,6 @@
 package reverie.task;
 
+import reverie.parser.DateTimeParser;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -1,6 +1,5 @@
 package reverie.task;
 
-import reverie.exception.ReverieException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -15,7 +15,7 @@ public class Deadline extends Task {
             DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
 
     // Constructor without time
-    public Deadline(String description, String by) throws ReverieException {
+    public Deadline(String description, String by) {
         super(description);
         this.by = by;
         DateTimeParser.ParseResult result = DateTimeParser.parseDateTime(by);
@@ -24,7 +24,7 @@ public class Deadline extends Task {
     }
 
     // Constructor with time
-    public Deadline(String description, String by, boolean hasTime) throws ReverieException {
+    public Deadline(String description, String by, boolean hasTime) {
         super(description);
         this.by = by;
         DateTimeParser.ParseResult result = DateTimeParser.parseDateTime(by);

--- a/src/main/java/reverie/task/Deadline.java
+++ b/src/main/java/reverie/task/Deadline.java
@@ -13,10 +13,23 @@ public class Deadline extends Task {
             DateTimeFormatter.ofPattern("HH:mm MMM dd yyyy", Locale.ENGLISH);
     private static final DateTimeFormatter OUTPUT_FORMAT_DATE_ONLY =
             DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
+
+    // Constructor without time
     public Deadline(String description, String by) throws ReverieException {
         super(description);
         this.by = by;
-        this.byDate = parseDate(by);
+        DateTimeParser.ParseResult result = DateTimeParser.parseDateTime(by);
+        this.byDateTime = result.getDateTime();
+        this.hasTime = result.hasTime();
+    }
+
+    // Constructor with time
+    public Deadline(String description, String by, boolean hasTime) throws ReverieException {
+        super(description);
+        this.by = by;
+        DateTimeParser.ParseResult result = DateTimeParser.parseDateTime(by);
+        this.byDateTime = result.getDateTime();
+        this.hasTime = hasTime;
     }
 
     public String getByString() {

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -43,7 +43,7 @@ public class Event extends Task {
     public boolean hasTime() {
         return hasTime;
     }
-    
+
     public String getFromString() {
         return from;
     }
@@ -52,12 +52,12 @@ public class Event extends Task {
         return to;
     }
 
-    public LocalDate getFromDate() {
-        return fromDate;
+    public LocalDateTime getFromDateTime() {
+        return fromDateTime;
     }
 
-    public LocalDate getToDate() {
-        return toDate;
+    public LocalDateTime getToDateTime() {
+        return toDateTime;
     }
 
     private LocalDate parseDate(String dateString) throws ReverieException {

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -74,8 +74,29 @@ public class Event extends Task {
     }
 
     // Infer the 'from' date when only time is provided
-    private LocalDateTime inferFromDateTime() {
-        
+    private LocalDateTime inferFromDateTime(LocalDateTime fromDateTime, LocalDateTime toDateTime,
+                                            DateTimeParser.ParseResult fromResult,
+                                            DateTimeParser.ParseResult toResult) {
+        // If 'from' has only time and 'to' has date+time
+        if (fromDateTime != null && toDateTime != null &&
+                fromResult.hasTime() && toResult.hasTime() &&
+                fromDateTime.toLocalDate().equals(LocalDate.now()) &&
+                !toDateTime.toLocalDate().equals(LocalDate.now())) {
+
+            LocalDate toDate = toDateTime.toLocalDate();
+            LocalTime fromTime = fromDateTime.toLocalTime();
+            LocalTime toTime = toDateTime.toLocalTime();
+
+            // If from_time is between 0000-toTime, use same day as 'to'
+            if (fromTime.isBefore(toTime) || fromTime.equals(toTime)) {
+                return LocalDateTime.of(toDate, fromTime);
+            } else {
+                // If from_time is after toTime, use previous day
+                return LocalDateTime.of(toDate.minusDays(1), fromTime);
+            }
+        }
+
+        return fromDateTime;
     }
 
     @Override

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -1,6 +1,8 @@
 package reverie.task;
 
 import reverie.parser.DateTimeParser;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -21,10 +23,19 @@ public class Event extends Task {
         super(description);
         this.from = from;
         this.to = to;
+
         DateTimeParser.ParseResult fromResult = DateTimeParser.parseDateTime(from);
         DateTimeParser.ParseResult toResult = DateTimeParser.parseDateTime(to);
-        this.fromDateTime = fromResult.getDateTime();
-        this.toDateTime = toResult.getDateTime();
+
+        LocalDateTime fromDateTime = fromResult.getDateTime();
+        LocalDateTime toDateTime = toResult.getDateTime();
+
+        // Handle smart date inference
+        fromDateTime = inferFromDateTime(fromDateTime, toDateTime, fromResult, toResult);
+        toDateTime = inferToDateTime(fromDateTime, toDateTime, fromResult, toResult);
+
+        this.fromDateTime = fromDateTime;
+        this.toDateTime = toDateTime;
         this.hasTime = fromResult.hasTime() || toResult.hasTime();
     }
 
@@ -33,8 +44,10 @@ public class Event extends Task {
         super(description);
         this.from = from;
         this.to = to;
+
         DateTimeParser.ParseResult fromResult = DateTimeParser.parseDateTime(from);
         DateTimeParser.ParseResult toResult = DateTimeParser.parseDateTime(to);
+
         this.fromDateTime = fromResult.getDateTime();
         this.toDateTime = toResult.getDateTime();
         this.hasTime = hasTime;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -17,7 +17,7 @@ public class Event extends Task {
             DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
 
     // Constructor without time
-    public Event(String description, String from, String to) throws ReverieException {
+    public Event(String description, String from, String to) {
         super(description);
         this.from = from;
         this.to = to;
@@ -29,7 +29,7 @@ public class Event extends Task {
     }
 
     // Constructor with time
-    public Event(String description, String from, String to, boolean hasTime) throws ReverieException {
+    public Event(String description, String from, String to, boolean hasTime) {
         super(description);
         this.from = from;
         this.to = to;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -40,6 +40,10 @@ public class Event extends Task {
         this.hasTime = hasTime;
     }
 
+    public boolean hasTime() {
+        return hasTime;
+    }
+    
     public String getFromString() {
         return from;
     }

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -59,11 +59,24 @@ public class Event extends Task {
     public LocalDateTime getToDateTime() {
         return toDateTime;
     }
-    
+
     @Override
     public String getFullStatus() {
-        String fromString = fromDate != null ? fromDate.format(OUTPUT_FORMAT) : from;
-        String toString = toDate != null ? toDate.format(OUTPUT_FORMAT) : to;
+        String fromString;
+        String toString;
+
+        if (fromDateTime != null) {
+            fromString = hasTime ? fromDateTime.format(OUTPUT_FORMAT_WITH_TIME) : fromDateTime.format(OUTPUT_FORMAT_DATE_ONLY);
+        } else {
+            fromString = from;
+        }
+
+        if (toDateTime != null) {
+            toString = hasTime ? toDateTime.format(OUTPUT_FORMAT_WITH_TIME) : toDateTime.format(OUTPUT_FORMAT_DATE_ONLY);
+        } else {
+            toString = to;
+        }
+
         return "[E]" + super.getFullStatus() + " (from: " + fromString + " to: " + toString + ")";
     }
 }

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -1,9 +1,8 @@
 package reverie.task;
 
 import reverie.exception.ReverieException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 public class Event extends Task {

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -1,5 +1,6 @@
 package reverie.task;
 
+import reverie.parser.DateTimeParser;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -16,12 +16,28 @@ public class Event extends Task {
     private static final DateTimeFormatter OUTPUT_FORMAT_DATE_ONLY =
             DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
 
+    // Constructor without time
     public Event(String description, String from, String to) throws ReverieException {
         super(description);
         this.from = from;
         this.to = to;
-        this.fromDate = parseDate(from);
-        this.toDate = parseDate(to);
+        DateTimeParser.ParseResult fromResult = DateTimeParser.parseDateTime(from);
+        DateTimeParser.ParseResult toResult = DateTimeParser.parseDateTime(to);
+        this.fromDateTime = fromResult.getDateTime();
+        this.toDateTime = toResult.getDateTime();
+        this.hasTime = fromResult.hasTime() || toResult.hasTime();
+    }
+
+    // Constructor with time
+    public Event(String description, String from, String to, boolean hasTime) throws ReverieException {
+        super(description);
+        this.from = from;
+        this.to = to;
+        DateTimeParser.ParseResult fromResult = DateTimeParser.parseDateTime(from);
+        DateTimeParser.ParseResult toResult = DateTimeParser.parseDateTime(to);
+        this.fromDateTime = fromResult.getDateTime();
+        this.toDateTime = toResult.getDateTime();
+        this.hasTime = hasTime;
     }
 
     public String getFromString() {

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -1,6 +1,5 @@
 package reverie.task;
 
-import reverie.exception.ReverieException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -8,10 +8,13 @@ import java.util.Locale;
 public class Event extends Task {
     protected String from;
     protected String to;
-    protected LocalDate fromDate;
-    protected LocalDate toDate;
-    private static final DateTimeFormatter INPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter OUTPUT_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
+    protected LocalDateTime fromDateTime;
+    protected LocalDateTime toDateTime;
+    protected boolean hasTime;
+    private static final DateTimeFormatter OUTPUT_FORMAT_WITH_TIME =
+            DateTimeFormatter.ofPattern("HH:mm MMM dd yyyy", Locale.ENGLISH);
+    private static final DateTimeFormatter OUTPUT_FORMAT_DATE_ONLY =
+            DateTimeFormatter.ofPattern("MMM dd yyyy", Locale.ENGLISH);
 
     public Event(String description, String from, String to) throws ReverieException {
         super(description);

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -73,6 +73,11 @@ public class Event extends Task {
         return toDateTime;
     }
 
+    // Infer the 'from' date when only time is provided
+    private LocalDateTime inferFromDateTime() {
+        
+    }
+
     @Override
     public String getFullStatus() {
         String fromString;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -59,15 +59,7 @@ public class Event extends Task {
     public LocalDateTime getToDateTime() {
         return toDateTime;
     }
-
-    private LocalDate parseDate(String dateString) throws ReverieException {
-        try {
-            return LocalDate.parse(dateString, INPUT_FORMAT);
-        } catch (DateTimeParseException e) {
-            throw new ReverieException("Invalid date format. Please use yyyy-MM-dd (e.g., 2019-12-02)");
-        }
-    }
-
+    
     @Override
     public String getFullStatus() {
         String fromString = fromDate != null ? fromDate.format(OUTPUT_FORMAT) : from;

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -100,8 +100,29 @@ public class Event extends Task {
     }
 
     // Infer the 'to' date when only time is provided
-    private LocalDateTime inferToDateTime() {
-        
+    private LocalDateTime inferToDateTime(LocalDateTime fromDateTime, LocalDateTime toDateTime,
+                                          DateTimeParser.ParseResult fromResult,
+                                          DateTimeParser.ParseResult toResult) {
+        // If 'to' has only time and 'from' has date+time
+        if (fromDateTime != null && toDateTime != null &&
+                fromResult.hasTime() && toResult.hasTime() &&
+                !fromDateTime.toLocalDate().equals(LocalDate.now()) &&
+                toDateTime.toLocalDate().equals(LocalDate.now())) {
+
+            LocalDate fromDate = fromDateTime.toLocalDate();
+            LocalTime fromTime = fromDateTime.toLocalTime();
+            LocalTime toTime = toDateTime.toLocalTime();
+
+            // If to_time is between fromTime-2400, use same day as 'from'
+            if (toTime.isAfter(fromTime) || toTime.equals(fromTime)) {
+                return LocalDateTime.of(fromDate, toTime);
+            } else {
+                // If to_time is before fromTime, use next day
+                return LocalDateTime.of(fromDate.plusDays(1), toTime);
+            }
+        }
+
+        return toDateTime;
     }
 
     @Override

--- a/src/main/java/reverie/task/Event.java
+++ b/src/main/java/reverie/task/Event.java
@@ -99,6 +99,11 @@ public class Event extends Task {
         return fromDateTime;
     }
 
+    // Infer the 'to' date when only time is provided
+    private LocalDateTime inferToDateTime() {
+        
+    }
+
     @Override
     public String getFullStatus() {
         String fromString;

--- a/src/main/java/reverie/ui/TaskList.java
+++ b/src/main/java/reverie/ui/TaskList.java
@@ -50,7 +50,9 @@ public class TaskList {
         String lowerKeyword = keyword.toLowerCase();
 
         for (int i = 0; i < tasks.size(); i++) {
-            if (tasks.get(i).getDescription().toLowerCase().contains(lowerKeyword)) {
+            // Search in the full task representation (including task number and status)
+            String fullEntry = (i + 1) + "." + tasks.get(i).getFullStatus();
+            if (fullEntry.toLowerCase().contains(lowerKeyword)) {
                 matchingIndices.add(i);
             }
         }


### PR DESCRIPTION
## Extension of Level-8: Intelligent Date Inference
This PR implements intelligent date inference for `Deadline` and `Event` tasks when users provide only time without specifying a date.

### Changes Made

#### 1. **Deadline Feature Enhancement**
- When `/by` contains only time (e.g., `1800`, `6:00 PM`), the system now defaults to **today's date**
- Example: `deadline submit report /by 1800` → deadline set to 18:00 today

#### 2. **Event Feature Enhancement**
Implemented smart date inference logic for events when one field has date+time and the other has only time:

**Case A: `/from` has date+time, `/to` has only time**
- If `to_time` ≥ `from_time`: Uses same date as `/from`
  - Example: `event meeting /from 2020-02-28 1700 /to 1900` → Feb 28 17:00 to Feb 28 19:00
- If `to_time` < `from_time`: Uses next day
  - Example: `event meeting /from 2020-02-28 1700 /to 0200` → Feb 28 17:00 to Feb 29 02:00

**Case B: `/from` has only time, `/to` has date+time**
- If `from_time` ≤ `to_time`: Uses same date as `/to`
  - Example: `event meeting /from 1400 /to 2020-03-01 1700` → Mar 01 14:00 to Mar 01 17:00
- If `from_time` > `to_time`: Uses previous day
  - Example: `event meeting /from 2000 /to 2020-03-01 1700` → Feb 29 20:00 to Mar 01 17:00

#### 3. **DateTimeParser Enhancement**
- Added case-insensitive AM/PM parsing
- Now accepts: `am`, `AM`, `pm`, `PM`, `Am`, `Pm`, etc.
- Input normalization for consistent parsing
